### PR TITLE
Add local install options and automatic conversion

### DIFF
--- a/dtype_diet.py
+++ b/dtype_diet.py
@@ -18,48 +18,62 @@ from collections import namedtuple
 
 # For a dtype count the nbr of conversions that aren't equal, the RAM cost
 # of the conversion and the column name
-AsType = namedtuple('AsType', ['dtype', 'nbr_different', 'nbytes', 'col'])
+AsType = namedtuple("AsType", ["dtype", "nbr_different", "nbytes", "col"])
+_fields = (
+    "column",
+    "current_dtype",
+    "proposed_dtype",
+    "current_memory",
+    "proposed_memory",
+    "ram_usage_improvement",
+)
+Row = namedtuple("Row", _fields, defaults=(None,) * len(_fields))
 
 
-def count_errors(ser, new_dtype, unsafe=False):
+def count_errors(ser, new_dtype):
     """After converting ser to new dtype, count whether items have isclose()"""
-    errors = 'ignore' if unsafe else None
-    tmp_ser = ser.astype(new_dtype, errors=errors)
+    tmp_ser = ser.astype(new_dtype)
     # metric will be a list of Trues if the change has equivalent value, False otherwise
     # checks for approx equal which may not be what we want
-    #metric = np.isclose(ser, tmp_ser)
+    # metric = np.isclose(ser, tmp_ser)
     metric = ser == tmp_ser
-    nbytes = tmp_ser.memory_usage(deep=True) 
+    nbytes = tmp_ser.memory_usage(deep=True)
     as_type = AsType(new_dtype, (~metric).sum(), nbytes, ser.name)
     return as_type
 
 
 def map_dtypes_to_choices(ser):
-    new_dtypes = {'int64': ['Int32', 'Int16', 'Int8'],
-                  'float64': ['float32', 'float16'],
-                  'object': ['category']}
+    new_dtypes = {
+        "int64": ["int32", "int16", "int8"],
+        "float64": ["float32", "float16"],
+        "object": ["category"],
+    }
     return new_dtypes.get(ser.dtype.name)
 
 
-def get_smallest_valid_conversion(ser, unsafe):
+def get_smallest_valid_conversion(ser):
     new_dtypes = map_dtypes_to_choices(ser)
     if new_dtypes:
         for new_dtype in reversed(new_dtypes):
-            as_type = count_errors(ser, new_dtype, unsafe)
+            as_type = count_errors(ser, new_dtype)
             if as_type.nbr_different == 0:
                 return as_type
     return None
 
 
 def get_improvement(as_type, current_nbytes):
+    report = (None, None, None)
     ram_usage_improvement = current_nbytes - as_type.nbytes
-    report = (as_type.col, current_nbytes, None, None, None)
     if ram_usage_improvement > 0:
-        report = (as_type.col, current_nbytes, as_type.nbytes, as_type.dtype, ram_usage_improvement)
+        report = (
+            as_type.nbytes,
+            as_type.dtype,
+            ram_usage_improvement,
+        )
     return report
 
 
-def report_on_dataframe(df, unit="MB", unsafe=False):
+def report_on_dataframe(df, unit="MB"):
     """[Report on columns that might be converted]
 
     Args:
@@ -67,52 +81,79 @@ def report_on_dataframe(df, unit="MB", unsafe=False):
         unit (str, optional): [byte, MB, GB]. Defaults to "MB".
     """
 
-    unit_map = {"MB": 1024, "GB": 1024*1024, "byte": 1}
+    unit_map = {"KB": 1024**1, "MB": 1024*2, "GB": 1024**3, "byte": 1}
     divide_by = unit_map[unit]
     list_of_conversions = []
 
     for col in df.columns:
-        current_dtype = df[col].dtype
-        as_type = get_smallest_valid_conversion(df[col], unsafe)
+        as_type = get_smallest_valid_conversion(df[col])
         nbytes = df[col].memory_usage(deep=True)
-        msg = None
+        # Init these attributes to be None
+        proposed_memory, proposed_dtype, ram_usage_improvement = None, None, None
+        # If improvement is found, replace the attributes
         if as_type:
-            col, current_bytes, after_bytes, proposed_dtype, ram_usage_improvement = get_improvement(as_type, nbytes)
-            current_memory = current_bytes / divide_by
-            after_memory = after_bytes / divide_by if after_bytes else None
-            ram_usage_improvement = ram_usage_improvement / divide_by if after_bytes else None
+            (
+                proposed_bytes,
+                proposed_dtype,
+                ram_usage_improvement,
+            ) = get_improvement(as_type, nbytes)
+            proposed_memory = proposed_bytes / divide_by
+            ram_usage_improvement = ram_usage_improvement / divide_by
+            proposed_dtype = proposed_dtype
 
-        list_of_conversions.append((col, current_dtype, proposed_dtype, current_memory, after_memory, ram_usage_improvement))
-    columns = ['Column', 'Current dtype','Proposed dtype', f'Current Memory ({unit})', f'Proposed Memory ({unit})', f'Ram Usage Improvement ({unit})']
+        row = Row(
+            column=col,
+            current_dtype=df[col].dtype,
+            current_memory=nbytes / divide_by,
+            proposed_memory=proposed_memory,
+            proposed_dtype=proposed_dtype,
+            ram_usage_improvement=ram_usage_improvement,
+        )
+        list_of_conversions.append(row)
+    columns = [
+        "Column",
+        "Current dtype",
+        "Proposed dtype",
+        f"Current Memory ({unit})",
+        f"Proposed Memory ({unit})",
+        f"Ram Usage Improvement ({unit})",
+    ]
     report_df = pd.DataFrame(list_of_conversions, columns=columns)
-    report_df['Ram Usage Improvement (%)'] =  report_df[f'Ram Usage Improvement ({unit})'] / report_df[f'Current Memory ({unit})']
-    report_df = report_df.set_index('Column')
+    report_df["Ram Usage Improvement (%)"] = (
+        report_df[f"Ram Usage Improvement ({unit})"]
+        / report_df[f"Current Memory ({unit})"]
+        * 100
+    )
+    report_df = report_df.set_index("Column")
     return report_df
 
-def optimize_dtypes(df, proposed_df, unsafe=False):
+
+def optimize_dtypes(df, proposed_df):
     new_df = df.copy()
-    errors = 'ignore' if unsafe else None
     for col in df.columns:
-        new_dtype = proposed_df.loc[col, 'Proposed dtype']
-        new_df[col] = new_df[col].astype(new_dtype, errors=errors)
+        new_dtype = proposed_df.loc[col, "Proposed dtype"]
+        if new_dtype:
+            new_df[col] = new_df[col].astype(new_dtype)
     return new_df
+
+
 def test_ser_ints():
     # check for low simple int
     ser = pd.Series([1] * 3)
-    as_type = count_errors(ser, 'int32')
+    as_type = count_errors(ser, "int32")
     assert as_type.nbr_different == 0
-    as_type = count_errors(ser, 'int16')
+    as_type = count_errors(ser, "int16")
     assert as_type.nbr_different == 0
-    as_type = count_errors(ser, 'int8')
+    as_type = count_errors(ser, "int8")
     assert as_type.nbr_different == 0
 
     # check for int needing bigger than int16
     ser = pd.Series([65536] * 3)
-    as_type = count_errors(ser, 'int32')
+    as_type = count_errors(ser, "int32")
     assert as_type.nbr_different == 0
-    as_type = count_errors(ser, 'int16')
+    as_type = count_errors(ser, "int16")
     assert as_type.nbr_different == 3
-    as_type = count_errors(ser, 'int8')
+    as_type = count_errors(ser, "int8")
     assert as_type.nbr_different == 3
 
 
@@ -121,13 +162,13 @@ if __name__ == "__main__":
 
     nbr_rows = 100
     df = pd.DataFrame()
-    df['a'] = [0] * nbr_rows
-    df['b'] = [256] * nbr_rows
-    df['c'] = [65_536] * nbr_rows
-    df['d'] = [1_100.0] * nbr_rows
-    df['e'] = [100_101.0] * nbr_rows
-    df['str_a'] = ['hello'] * nbr_rows
-    df['str_b'] = [str(n) for n in range(nbr_rows)]
+    df["a"] = [0] * nbr_rows
+    df["b"] = [256] * nbr_rows
+    df["c"] = [65_536] * nbr_rows
+    df["d"] = [1_100.0] * nbr_rows
+    df["e"] = [100_101.0] * nbr_rows
+    df["str_a"] = ["hello"] * nbr_rows
+    df["str_b"] = [str(n) for n in range(nbr_rows)]
     report_on_dataframe(df)
 
     print("convert_dtypes does a slightly different job:")

--- a/dtype_diet.py
+++ b/dtype_diet.py
@@ -36,9 +36,10 @@ def count_errors(ser, new_dtype):
     # metric will be a list of Trues if the change has equivalent value, False otherwise
     # checks for approx equal which may not be what we want
     # metric = np.isclose(ser, tmp_ser)
-    metric = ser == tmp_ser
+
+    ndiff = len(ser.compare(tmp_ser))  # pandas >= 1.1.0
     nbytes = tmp_ser.memory_usage(deep=True)
-    as_type = AsType(new_dtype, (~metric).sum(), nbytes, ser.name)
+    as_type = AsType(new_dtype, ndiff, nbytes, ser.name)
     return as_type
 
 
@@ -81,7 +82,7 @@ def report_on_dataframe(df, unit="MB"):
         unit (str, optional): [byte, MB, GB]. Defaults to "MB".
     """
 
-    unit_map = {"KB": 1024**1, "MB": 1024*2, "GB": 1024**3, "byte": 1}
+    unit_map = {"KB": 1024 ** 1, "MB": 1024 * 2, "GB": 1024 ** 3, "byte": 1}
     divide_by = unit_map[unit]
     list_of_conversions = []
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(
+   name='dtype_diet',
+   version='0.0.1',
+   description='A useful module',
+   author='Ian Ozsvald',
+   author_email='foomail@foo.com',
+   packages=[],  #same as name
+   install_requires=[], #external packages as dependencies
+)


### PR DESCRIPTION
- [x]  Adding setup.py allow installing the package locally, first step before having  a proper pip package. `python setup.py` or `pip install -e .` will do it.
- [x] For now report_on_dataframe only prints the possible conversion. It should return a dictionary/dataframe, which can be consumed later to automatically convert the dtype. As optimization depends on the use case, may provide two options as first step. 
1. Optimize computation (use fp32 if possible)
2. Optimize memory (use fp16 whenever possible)
3. Better handling cateogry dtype (handle NaN)